### PR TITLE
Don't assume WP_CONTENT_DIR is /wp-content/

### DIFF
--- a/wp-less.php
+++ b/wp-less.php
@@ -44,10 +44,7 @@ if ( ! class_exists( 'wp_less' ) ) {
 				return $src;
 
 			// get file path from $src
-			$less_path_parts = explode( '?', str_replace( get_bloginfo( 'template_url' ), get_template_directory(), $src ) );
-			
-			$less_path = reset( $less_path_parts );
-			$query_string = end( $less_path_parts );
+			list( $less_path, $query_string ) = explode( '?', str_replace( WP_CONTENT_URL, WP_CONTENT_DIR, $src ) );
 			
 			// output css file name
 			$css_path = $this->get_cache_dir() . "/$handle.css";


### PR DESCRIPTION
wp-less currently breaks if you change `WP_CONTENT_DIR` to be something other than `/wp-content/`.

We use the following layout for our projects: http://github.com/humanmade/HM-Base/.

Basically WordPress is submoduled into `/wordpress/` and then `WP_CONTENT_DIR` is set to `/` so web root looks like:

```
plugins/
themes/
index.php
uploads/
wordpress/
wp-config.php
```
