### PR TITLE
PHP Fatal error: Call-time pass-by-reference has been removed; If you would like to pass argument by reference, modify the declaration of do_action().

### DIFF
--- a/wp-less.php
+++ b/wp-less.php
@@ -192,7 +192,7 @@ class wp_less {
 				$less->unregisterFunction( $name );
 
 			// allow devs to mess around with the less object configuration
-			do_action( 'lessc', &$less );
+			do_action( 'lessc', array( &$less ) );
 
 			$less_cache = $less->cachedCompile( $cache[ 'less' ] );
 


### PR DESCRIPTION
Hey guys, line 195 of wp-less.php needs to be

``` php
do_action( 'lessc', array( &$less ) );
```

(i.e. you need to wrap the arg in an array when passing by reference). Tested in a child theme of twentytwelve.
