### PR TITLE
do_action_ref_array() to remove array level for lessc object hook

### DIFF
--- a/wp-less.php
+++ b/wp-less.php
@@ -192,7 +192,7 @@ class wp_less {
 				$less->unregisterFunction( $name );
 
 			// allow devs to mess around with the less object configuration
-			do_action( 'lessc', array( &$less ) );
+			do_action_ref_array( 'lessc', array( &$less ) );
 
 			$less_cache = $less->cachedCompile( $cache[ 'less' ] );
 


### PR DESCRIPTION
Wrapping in array works to pass reference, but with vanilla `do_action()` would need to confusingly access var in array inside callback.
