### PR TITLE
Filter to force compile

### DIFF
--- a/wp-less.php
+++ b/wp-less.php
@@ -194,7 +194,7 @@ class wp_less {
 			// allow devs to mess around with the less object configuration
 			do_action_ref_array( 'lessc', array( &$less ) );
 
-			$less_cache = $less->cachedCompile( $cache[ 'less' ] );
+			$less_cache = $less->cachedCompile( $cache[ 'less' ], apply_filters( 'less_force_compile', false ) );
 
 			if ( empty( $cache ) || empty( $cache[ 'less' ][ 'updated' ] ) || $less_cache[ 'updated' ] > $cache[ 'less' ][ 'updated' ] || $this->vars !== $cache[ 'vars' ] ) {
 				file_put_contents( $cache_path, serialize( array( 'vars' => $this->vars, 'less' => $less_cache ) ) );


### PR DESCRIPTION
Changes made to functions or variables registered in PHP, such as when working with the Theme Customizer, don't cause LESS files to be recompiled, so the changes aren't visible in the Customizer preview or the front-end unless a LESS file is updated manually.

A second parameter is available in the `lessc::cachedCompile()` method for forcing the files to be rebuilt, so this filter allows it to be updated when necessary.
