### PR TITLE
Update wp-less.php

### DIFF
--- a/wp-less.php
+++ b/wp-less.php
@@ -13,10 +13,13 @@ License:      MIT
 // Busted! No direct file access
 ! defined( 'ABSPATH' ) AND exit;
 
-
-// load LESS parser
-! class_exists( 'lessc' ) AND require_once( 'vendor/leafo/lessphp/lessc.inc.php' );
-
+// load the autoloader if it's present 
+if ( file_exists( __DIR__ . '/vendor/autoload.php' ) ) {
+	require __DIR__ . '/vendor/autoload.php';
+} else if ( file_exists( __DIR__.'/vendor/leafo/lessphp/lessc.inc.php' ) ) {
+	// load LESS parser
+	require_once( __DIR__.'/vendor/leafo/lessphp/lessc.inc.php' );
+}
 
 if ( ! class_exists( 'wp_less' ) ) {
 	// add on init to support theme customiser in v3.4


### PR DESCRIPTION
If I run composer on the plugins directory everything works as expected.

However, if my site has a composer.json, and this plugin is specified as a dependency, the vendor folder is in a different location, and the require fails. So instead, load the autoloader if it's present in a vendor folder. If it isn't, then assume it's been included somewhere else.
