### PR TITLE
Match the URL schemes 

### DIFF
--- a/wp-less.php
+++ b/wp-less.php
@@ -148,6 +148,13 @@ class wp_less {
 		// get file path from $src
 		if ( ! strstr( $src, '?' ) ) $src .= '?'; // prevent non-existent index warning when using list() & explode()
 
+		// Match the URL schemes between WP_CONTENT_URL and $src, 
+		// so the str_replace further down will work
+		$src_scheme = parse_url( $src, PHP_URL_SCHEME );
+		$wp_content_url_scheme = parse_url( WP_CONTENT_URL, PHP_URL_SCHEME );
+		if ( $src_scheme != $wp_content_url_scheme )
+			$src = set_url_scheme( $src, $wp_content_url_scheme );
+		
 		list( $less_path, $query_string ) = explode( '?', str_replace( WP_CONTENT_URL, WP_CONTENT_DIR, $src ) );
 
 		// output css file name


### PR DESCRIPTION
Currently, if the scheme of the URL passed in does not match the scheme of `WP_CONTENT_URL`, then the search and replace `str_replace( WP_CONTENT_URL, WP_CONTENT_DIR, $src )` does not occur, and the `$src` string remains a URL rather than being converted to a file path.

For example, we had this situation, where the replace failed (note different schemes):

``` php
str_replace( 'http://example.com/somesite/wp-content', '/srv/www/someproject/htdocs/wp-content', 'https://example.com/somesite/wp-content/themes/some-theme/assets/less/wp-admin.less?ver=3.7.1' )
```

This pull request matches the schemes if they differ, forcing the `$src` scheme to the scheme of `WP_CONTENT_URL`.
