### PR TITLE
Correct directory to place dependency of lessphp

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ If you are using git to clone the repository, do the following:
     git clone git://github.com/sanchothefat/wp-less.git wp-less
 
 If you are downloading the `.zip` or `.tar`, don't forget to download the [lessphp
-dependency too](https://github.com/leafo/lessphp) and copy it into the `lessc`
-folder.
+dependency too](https://github.com/leafo/lessphp) and copy it into the `vendor/leafo/lessphp`
+directory.
 
 Then install the lessphp dependency using:
 


### PR DESCRIPTION
The README instructed the user to place the lessphp code into `lessc`
directory. However, this is incorrect and should read as
"vendor/leafo/lessphp"
