### PR TITLE
Lessphp as git submodule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-/vendor/
 composer.lock
 .DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vendor/leafo/lessphp"]
+	path = vendor/leafo/lessphp
+	url = https://github.com/leafo/lessphp.git

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ before deploying them.
 
 If you are using git to clone the repository, do the following:
 
-    git clone git://github.com/sanchothefat/wp-less.git wp-less
+    git clone --recursive git://github.com/sanchothefat/wp-less.git wp-less
+
+Should you forget to add the recursive flag as above, then run the following git commands
+
+    git submodule init
+    git submodule update
 
 If you are downloading the `.zip` or `.tar`, don't forget to download the [lessphp
 dependency too](https://github.com/leafo/lessphp) and copy it into the `lessc`


### PR DESCRIPTION
Instead of giving the users the instructions to also download another git repository, let's include it as a submodule.

This would ensure that everything is now kept up to date -- whenever we hear of updates from lessphp, then we just execute the following commands

```
 git submodule update
 git commit -a
 git push ...
```
