### PR TITLE
Force LESS regeneration when a variable change is detected

### DIFF
--- a/wp-less.php
+++ b/wp-less.php
@@ -204,8 +204,8 @@ class wp_less {
 			// allow devs to mess around with the less object configuration
 			do_action_ref_array( 'lessc', array( &$less ) );
 
-			// $less->cachedCompile only checks for changed file modification times (filemtime)
-			// if using the theme customiser (i.e. change variables) then force a compile
+			// $less->cachedCompile only checks for changed file modification times
+			// if using the theme customiser (changed variables not files) then force a compile
 			if ( $this->vars !== $cache[ 'vars' ] ) { 
 				$force = true; 
 			} else { 


### PR DESCRIPTION
I have been experiencing an issue relating to the theme customiser. When making changes to colour etc the theme preview was not being updated.

It looks like the `$less->cachedCompile` method checks the file modification time and will only recompile if the files have actually changed. During theme customisation the files do not change but the variables passed into LESS do.

We can force a cachedCompile when a variable change is detect.

Let me know your thoughts ... less php should probably implement a fix for this longer term?
